### PR TITLE
BL-12241 remove stop button during Update Preview step

### DIFF
--- a/src/BloomBrowserUI/publish/ReaderPublish/ReaderPublishScreen.tsx
+++ b/src/BloomBrowserUI/publish/ReaderPublish/ReaderPublishScreen.tsx
@@ -128,6 +128,11 @@ const ReaderPublishScreenInternal: React.FunctionComponent<{
                 case "stopped":
                     setClosePending(true);
                     break;
+                case "UpdatingPreview":
+                    setProgressState(ProgressState.Working);
+                    setClosePending(false);
+                    setHeading(publishing);
+                    break;
                 case "UsbStarted":
                     setClosePending(false);
                     setHeading(publishing);

--- a/src/BloomBrowserUI/publish/ReaderPublish/ReaderPublishScreen.tsx
+++ b/src/BloomBrowserUI/publish/ReaderPublish/ReaderPublishScreen.tsx
@@ -129,9 +129,9 @@ const ReaderPublishScreenInternal: React.FunctionComponent<{
                     setClosePending(true);
                     break;
                 case "UpdatingPreview":
-                    setProgressState(ProgressState.Working);
                     setClosePending(false);
                     setHeading(publishing);
+                    setProgressState(ProgressState.Working);
                     break;
                 case "UsbStarted":
                     setClosePending(false);

--- a/src/BloomExe/Publish/BloomPub/PublishToBloomPubApi.cs
+++ b/src/BloomExe/Publish/BloomPub/PublishToBloomPubApi.cs
@@ -99,7 +99,6 @@ namespace Bloom.Publish.BloomPub
 			{
 #if !__MonoCS__
 				SetState("UpdatingPreview");
-				_publishApi.UpdatePreviewIfNeeded(request);
 				// In 5.6, we should consider removing this UpdatePreviewIfNeeded line as it does not
 				// currently appear to be accomplishing anything. Also in "wifi/start" and 
 				// "file/save" endpoints below.

--- a/src/BloomExe/Publish/BloomPub/PublishToBloomPubApi.cs
+++ b/src/BloomExe/Publish/BloomPub/PublishToBloomPubApi.cs
@@ -98,12 +98,13 @@ namespace Bloom.Publish.BloomPub
 			apiHandler.RegisterEndpointHandler(kApiUrlPart + "usb/start", request =>
 			{
 #if !__MonoCS__
-
-				SetState("UsbStarted");
+				SetState("UpdatingPreview");
+				_publishApi.UpdatePreviewIfNeeded(request);
 				// In 5.6, we should consider removing this UpdatePreviewIfNeeded line as it does not
 				// currently appear to be accomplishing anything. Also in "wifi/start" and 
 				// "file/save" endpoints below.
 				_publishApi.UpdatePreviewIfNeeded(request);
+				SetState("UsbStarted");
 				_usbPublisher.Connect(request.CurrentBook, _publishApi._thumbnailBackgroundColor, _publishApi.GetSettings());
 #endif
 				request.PostSucceeded();
@@ -119,8 +120,9 @@ namespace Bloom.Publish.BloomPub
 			}, true);
 			apiHandler.RegisterEndpointHandler(kApiUrlPart + "wifi/start", request =>
 			{
-				SetState("ServingOnWifi");
+				SetState("UpdatingPreview");
 				_publishApi.UpdatePreviewIfNeeded(request);
+				SetState("ServingOnWifi");
 				_wifiPublisher.Start(request.CurrentBook, request.CurrentCollectionSettings, _publishApi._thumbnailBackgroundColor, _publishApi.GetSettings());
 				
 				request.PostSucceeded();
@@ -135,8 +137,9 @@ namespace Bloom.Publish.BloomPub
 
 			apiHandler.RegisterEndpointHandler(kApiUrlPart + "file/save", request =>
 			{
-				SetState("SavingFile");
+				SetState("UpdatingPreview");
 				_publishApi.UpdatePreviewIfNeeded(request);
+				SetState("SavingFile");
 				FilePublisher.Save(request.CurrentBook, _bookServer, _publishApi._thumbnailBackgroundColor, _progress, _publishApi.GetSettings());
 				SetState("stopped");
 				request.PostSucceeded();


### PR DESCRIPTION
Changes stacked on top of Jeffrey's PR https://github.com/BloomBooks/BloomDesktop/pull/5876

If a user e.g. changes the cover color and then publishes a bloomPub, we first run UpdatePreview. Weird behavior happens if he user hits the "stop" button while UpdatePreview is running. Since we normally don't show a stop button when previews are generating anyway, this will wait to show the "stop" button until after UpdatePreview has finished